### PR TITLE
ci: run e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
+name: ci
 on: [push]
 
 jobs:
   build_and_test:
-    name: CI
+    name: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,14 @@
+name: e2e
+on: [push]
+
+jobs:
+  build_and_test:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cd tests && docker-compose up -d
+      - run: TEST_INTEGRATION=1 TEST_KAFKA_ADDR="localhost:9092" cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,12 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,18 +333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
-name = "libz-sys"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,7 +503,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slab",
- "tokio",
 ]
 
 [[package]]
@@ -531,7 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
 dependencies = [
  "libc",
- "libz-sys",
  "num_enum",
  "pkg-config",
 ]
@@ -669,16 +649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
-dependencies = [
- "once_cell",
- "pin-project-lite",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,12 +674,6 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["kafka"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rdkafka = "0.28.0"
+rdkafka = { version = "0.28.0", default-features = false }
 serde = "1.0.137"
 serde_json = "1.0.81"
 bincode = "1.3.3"

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5,8 +5,6 @@ use assert_cmd::Command;
 static READ_HUMAN: &str = r#"Message { topic: "topic", partition: 0, offset: 0, timestamp: Some(CreateTime(1663602628526)), headers: "NONE", key: Some("banana-key"), payload: Some("platanos") }"#;
 static READ_JSON: &str = r#"{"topic":"topic","partition":0,"offset":0,"timestamp":{"CreateTime":1663602628526},"headers":null,"key":[98,97,110,97,110,97,45,107,101,121],"payload":[112,108,97,116,97,110,111,115]}"#;
 
-// TODO(dom:test): read from kafka
-
 macro_rules! assert_output {
     ($output:expr, $matcher:expr) => {
         let got = std::str::from_utf8(&$output).expect("non-unicode bytes in output");
@@ -26,7 +24,7 @@ fn test_cp() {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.arg("cp")
         .arg("./tests/fixture.kbin")
-        .arg(format!("kafka://{}/0", addr));
+        .arg(format!("kafka://{}/topic", addr));
 
     let output = cmd.unwrap();
 
@@ -36,10 +34,13 @@ fn test_cp() {
     assert!(output.status.success());
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    cmd.arg("read").arg(format!("kafka://{}/0", addr));
+    cmd.arg("read").arg(format!("kafka://{}/topic", addr));
 
     let output = cmd.unwrap();
-    assert_output!(output.stdout, READ_HUMAN);
+    assert_output!(
+        output.stdout,
+        r#"key: Some("banana-key"), payload: Some("platanos")"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
Speed up builds and run e2e tests.

---

* build: disable tokio feature on rdkafka (9ce2572)

      Removes tokio from the dependency tree.

* ci: run e2e tests (efe9a88)