### PR TITLE
ci: run e2e only for e2e job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           toolchain: stable
       - run: cd tests && docker-compose up -d
-      - run: TEST_INTEGRATION=1 TEST_KAFKA_ADDR="localhost:9092" cargo test --all-features
+      - run: TEST_INTEGRATION=1 TEST_KAFKA_ADDR="localhost:9092" cargo test --test e2e --all-features


### PR DESCRIPTION
Avoids running all the tests twice!

---

* ci: run e2e only for e2e job (eaec423)

      Skip running all other tests in the e2e job - run only those in the e2e test
      target.