### PR TITLE
feat: tail-relative offsets

### DIFF
--- a/src/cli/common/offset.rs
+++ b/src/cli/common/offset.rs
@@ -10,15 +10,19 @@ pub(crate) struct OffsetClap {
     /// Restrict messages read from the source to the specified offsets.
     ///
     /// Offsets are inclusive and in the form "start", or with an optional end
-    /// offset as "start:end"
+    /// offset as "start:end". Negative start values are relative to the current
+    /// partition offset.
     ///
     ///   - read all messages from offset 42, inclusive: "42"
+    ///
+    ///   - read the 3 most recent messages: -3
     ///
     ///   - read messages 42 to 100, inclusive: "42:100"
     ///
     ///   - read all messages up to (and including) offset 1234: ":1234"
     ///
     ///   - read only message number 42: "42:42"
+    ///
     #[clap(short, long, parse(try_from_str), conflicts_with = "time-range")]
     offset: Option<OffsetRange>,
 
@@ -73,7 +77,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match self.0.next()? {
-                Ok(v) if self.1.cmp(&v) == None => {
+                Ok(v) if self.1.cmp(&v).is_none() => {
                     panic!("cannot compare offset");
                 }
                 Ok(v) if self.1.cmp(&v) == Some(Ordering::Greater) => return None,

--- a/src/sink/file.rs
+++ b/src/sink/file.rs
@@ -19,7 +19,7 @@ impl FileSink {
         let f = OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&path)
+            .open(path)
             .with_context(|| format!("failed to open file {} for writing", path.display()))?;
 
         Ok(Self {

--- a/src/source/kafka.rs
+++ b/src/source/kafka.rs
@@ -49,11 +49,16 @@ pub fn new(
 
     // If a start offset was provided, seek the consumer to it to skip the prior
     // messages.
-    let offset = if let Some(offset) = start_offset {
-        offset_start = offset;
-        Offset::Offset(offset)
-    } else {
-        Offset::Beginning
+    let offset = match start_offset {
+        Some(v) if v < 0 => {
+            offset_start = offset_end + v;
+            Offset::OffsetTail(-v)
+        }
+        Some(v) => {
+            offset_start = v;
+            Offset::Offset(v)
+        }
+        None => Offset::Beginning,
     };
 
     let mut targets = TopicPartitionList::new();

--- a/tests/kafka.rs
+++ b/tests/kafka.rs
@@ -51,3 +51,72 @@ fn test_produce_consume() {
     assert_eq!(got.key(), msg.key());
     assert_eq!(got.payload(), msg.payload());
 }
+
+#[test]
+fn test_consume_tail() {
+    let addr = maybe_skip_integration!();
+
+    static TOPIC: &str = "topic";
+
+    let kafka_config = KafkaOpts {
+        timeout: Duration::from_secs(5),
+        group: "bananas".to_string(),
+        additional_args: vec![],
+    };
+
+    let tail = Message::new(
+        TOPIC,
+        0,
+        0,
+        None,
+        None,
+        Some("banana-key".into()),
+        Some("tail message".into()),
+    );
+
+    {
+        let mut sink = ktool::sink::kafka::Kafka::new(
+            vec![addr.clone()],
+            TOPIC.to_string(),
+            Some(0),
+            &kafka_config,
+        )
+        .expect("failed to initialise kafka sink");
+
+        let msg = Message::new(
+            TOPIC,
+            0,
+            0,
+            None,
+            None,
+            Some("banana-key".into()),
+            Some("platanos".into()),
+        );
+
+        sink.write(&msg).expect("publishing message failed");
+        sink.write(&msg).expect("publishing message failed");
+        sink.write(&msg).expect("publishing message failed");
+        sink.write(&msg).expect("publishing message failed");
+        sink.write(&tail).expect("publishing message failed");
+        sink.flush().expect("failed to flush producer");
+    }
+
+    let mut source = ktool::source::kafka::new(
+        vec![addr],
+        TOPIC.to_string(),
+        Some(0),
+        &kafka_config,
+        Some(-1),
+    )
+    .expect("failed to initialise kafka source");
+
+    let got = source
+        .next()
+        .expect("no message received")
+        .expect("unexpected consume error");
+
+    assert_eq!(got.topic(), tail.topic());
+    assert_eq!(got.headers(), tail.headers());
+    assert_eq!(got.key(), tail.key());
+    assert_eq!(got.payload(), tail.payload());
+}


### PR DESCRIPTION
Support specifying "tail" offsets using negative offsets.

For example, to read the most recent published message in a partition, specify `--offset=-1`

---

* feat: tail-relative offsets (99fab19)

      Support for specifying read offsets relative to the most recently
      published messages in a partition (queue tail).