### PR TITLE
feat: base64-encoded json output

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,3 +12,4 @@ jobs:
           toolchain: stable
       - run: cd tests && docker-compose up -d
       - run: TEST_INTEGRATION=1 TEST_KAFKA_ADDR="localhost:9092" cargo test --test e2e --all-features
+      - run: TEST_INTEGRATION=1 TEST_KAFKA_ADDR="localhost:9092" cargo test --test kafka --all-features

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,11 @@
 # To run manually:
 #   pre-commit run --all
 
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
+
 repos:
   - repo: https://github.com/domodwyer/pre-commit
-    rev: v3.4.1
+    rev: v3.5.0
     hooks:
       - id: rust-clippy
         stages: [commit, push]
@@ -36,7 +38,7 @@ repos:
         stages: [push]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [commit, manual]
@@ -55,7 +57,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.27.0
+    rev: v2.37.0
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +334,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_matches",
+ "base64",
  "bincode",
  "clap",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "3.1.18", features = ["derive"] }
 thiserror = "1.0.37"
 anyhow = "1.0.66"
 indicatif = { version = "0.16.2", features = ["improved_unicode"] }
+base64 = "0.13.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.5"

--- a/src/cli/common/offset.rs
+++ b/src/cli/common/offset.rs
@@ -299,4 +299,22 @@ mod tests {
         input = "1:2:3",
         want = Err(OffsetError::TooManyParts)
     );
+
+    test_parse_offset!(
+        tail_relative,
+        input = "-42",
+        want = Ok(OffsetRange {
+            start: -42,
+            end: None,
+        })
+    );
+
+    test_parse_offset!(
+        tail_relative_and_end,
+        input = "-42:12",
+        want = Ok(OffsetRange {
+            start: -42,
+            end: Some(12),
+        })
+    );
 }

--- a/src/file_codec.rs
+++ b/src/file_codec.rs
@@ -1,3 +1,5 @@
+//! Binary file format codec, serialising a [`Message`] into an on-disk format.
+
 use std::io::ErrorKind;
 
 use crate::message::Message;

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -1,0 +1,172 @@
+//! JSON representation of a [`Message`], used in CLI output.
+
+use std::collections::BTreeMap;
+
+use crate::message::{Message, Timestamp};
+
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Base64Bytes<'m>(#[serde(serialize_with = "base64_serialise")] &'m [u8]);
+
+fn base64_serialise<S>(v: &'_ [u8], s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoded = base64::encode(v);
+    s.serialize_str(&encoded)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct JsonMessage<'m> {
+    topic: &'m str,
+    partition: i32,
+    offset: i64,
+    timestamp: Option<Timestamp>,
+    headers: Option<BTreeMap<&'m str, Base64Bytes<'m>>>,
+    key: Option<Base64Bytes<'m>>,
+    payload: Option<Base64Bytes<'m>>,
+}
+
+impl<'m> From<&'m Message> for JsonMessage<'m> {
+    fn from(m: &'m Message) -> Self {
+        Self {
+            topic: m.topic(),
+            partition: m.partition(),
+            offset: m.offset(),
+            timestamp: m.timestamp().cloned(),
+            headers: m.headers().map(|v| {
+                v.iter()
+                    .map(|(k, v)| (k.as_str(), Base64Bytes(v)))
+                    .collect()
+            }),
+            key: m.key().map(Base64Bytes),
+            payload: m.payload().map(Base64Bytes),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_json {
+        (
+            $name:ident,
+            msg = $msg:expr,
+            want = $want:literal
+        ) => {
+            paste::paste! {
+                #[test]
+                fn [<test_json_representation_ $name>]() {
+                    let msg: Message = $msg;
+
+					let json = JsonMessage::from(&msg);
+                    let got = serde_json::to_string_pretty(&json).expect("failed to serialise message");
+
+					let want = $want;
+                    assert_eq!(got, $want, "got:\n{got}\nwant:\n{want}");
+                }
+            }
+        };
+    }
+
+    test_json!(
+        all_fields,
+        msg = Message::new(
+            "bananas",
+            42,
+            1234,
+            Some(Timestamp::CreateTime(11223344)),
+            Some(headers([("map_key1", "value"), ("map_key2", "plátanos")])),
+            Some("plátanos".into()),
+            Some("banana-payload-🍌".into()),
+        ),
+        want = r#"{
+  "topic": "bananas",
+  "partition": 42,
+  "offset": 1234,
+  "timestamp": {
+    "CreateTime": 11223344
+  },
+  "headers": {
+    "map_key1": "dmFsdWU=",
+    "map_key2": "cGzDoXRhbm9z"
+  },
+  "key": "cGzDoXRhbm9z",
+  "payload": "YmFuYW5hLXBheWxvYWQt8J+NjA=="
+}"#
+    );
+
+    test_json!(
+        optional_nones,
+        msg = Message::new("bananas", 42, 1234, None, None, None, None),
+        want = r#"{
+  "topic": "bananas",
+  "partition": 42,
+  "offset": 1234,
+  "timestamp": null,
+  "headers": null,
+  "key": null,
+  "payload": null
+}"#
+    );
+
+    test_json!(
+        optional_empty,
+        msg = Message::new(
+            "bananas",
+            42,
+            1234,
+            None,
+            Some(Default::default()),
+            Some(vec![]),
+            Some(vec![])
+        ),
+        want = r#"{
+  "topic": "bananas",
+  "partition": 42,
+  "offset": 1234,
+  "timestamp": null,
+  "headers": {},
+  "key": "",
+  "payload": ""
+}"#
+    );
+
+    test_json!(
+        non_printable,
+        msg = Message::new(
+            "bananas",
+            42,
+            1234,
+            None,
+            Some(headers([("test", [0x00, 0x42, 0x01, 0xFF])])),
+            Some(vec![0x00, 0x42, 0x02, 0xFF]),
+            Some(vec![0x00, 0x42, 0x03, 0xFF])
+        ),
+        want = r#"{
+  "topic": "bananas",
+  "partition": 42,
+  "offset": 1234,
+  "timestamp": null,
+  "headers": {
+    "test": "AEIB/w=="
+  },
+  "key": "AEIC/w==",
+  "payload": "AEID/w=="
+}"#
+    );
+
+    fn headers<T, K, V>(input: T) -> BTreeMap<String, Vec<u8>>
+    where
+        T: IntoIterator<Item = (K, V)>,
+        K: ToString,
+        V: Into<Vec<u8>>,
+    {
+        input
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.into()))
+            .collect()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod file_codec;
+pub mod json_output;
 pub mod message;
 pub mod sink;
 pub mod source;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3,14 +3,14 @@ mod common;
 use assert_cmd::Command;
 
 static READ_HUMAN: &str = r#"Message { topic: "topic", partition: 0, offset: 0, timestamp: Some(CreateTime(1663602628526)), headers: "NONE", key: Some("banana-key"), payload: Some("platanos") }"#;
-static READ_JSON: &str = r#"{"topic":"topic","partition":0,"offset":0,"timestamp":{"CreateTime":1663602628526},"headers":null,"key":[98,97,110,97,110,97,45,107,101,121],"payload":[112,108,97,116,97,110,111,115]}"#;
+static READ_JSON: &str = r#"{"topic":"topic","partition":0,"offset":0,"timestamp":{"CreateTime":1663602628526},"headers":null,"key":"YmFuYW5hLWtleQ==","payload":"cGxhdGFub3M="}"#;
 
-macro_rules! assert_output {
+macro_rules! assert_output_contains {
     ($output:expr, $matcher:expr) => {
         let got = std::str::from_utf8(&$output).expect("non-unicode bytes in output");
         assert!(
             got.contains($matcher),
-            "expected {} in output: {}",
+            "expected:\n{}\nin output:\n{}",
             $matcher,
             got
         )
@@ -28,16 +28,16 @@ fn test_cp() {
 
     let output = cmd.unwrap();
 
-    assert_output!(output.stderr, "read complete");
-    assert_output!(output.stderr, "write complete");
-    assert_output!(output.stdout, "complete - copied 1 messages");
+    assert_output_contains!(output.stderr, "read complete");
+    assert_output_contains!(output.stderr, "write complete");
+    assert_output_contains!(output.stdout, "complete - copied 1 messages");
     assert!(output.status.success());
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     cmd.arg("read").arg(format!("kafka://{}/topic", addr));
 
     let output = cmd.unwrap();
-    assert_output!(
+    assert_output_contains!(
         output.stdout,
         r#"key: Some("banana-key"), payload: Some("platanos")"#
     );
@@ -50,8 +50,8 @@ fn test_read_file() {
 
     let output = cmd.unwrap();
 
-    assert_output!(output.stderr, "opening dump file");
-    assert_output!(output.stdout, READ_HUMAN);
+    assert_output_contains!(output.stderr, "opening dump file");
+    assert_output_contains!(output.stdout, READ_HUMAN);
     assert!(output.status.success());
 }
 
@@ -62,7 +62,7 @@ fn test_read_file_json() {
 
     let output = cmd.unwrap();
 
-    assert_output!(output.stderr, "opening dump file");
-    assert_output!(output.stdout, READ_JSON);
+    assert_output_contains!(output.stderr, "opening dump file");
+    assert_output_contains!(output.stdout, READ_JSON);
     assert!(output.status.success());
 }

--- a/tests/kafka.rs
+++ b/tests/kafka.rs
@@ -56,7 +56,7 @@ fn test_produce_consume() {
 fn test_consume_tail() {
     let addr = maybe_skip_integration!();
 
-    static TOPIC: &str = "topic";
+    static TOPIC: &str = "another-topic";
 
     let kafka_config = KafkaOpts {
         timeout: Duration::from_secs(5),


### PR DESCRIPTION
Encodes (potentially) binary fields in the message as base64 strings, instead of arrays-of-bytes.

---

* feat: base64-encoded binary in JSON output (0142d55)

      Encodes any (potential) binary content in a Kafka message using base64.

* test: run Kafka integration tests (bbeb421)


* ci: bump lint versions (f0ea9e4)